### PR TITLE
in both browse and read templates, wrap actions in variable to make them excludable

### DIFF
--- a/bread/templates/bread/includes/browse.html
+++ b/bread/templates/bread/includes/browse.html
@@ -77,8 +77,10 @@
 </table>
 <br/>
 
-{% if may_add %}
-  <a href="{% url bread.add_url_name %}">{% trans "Add" %}</a>
-{% elif debug %}
-  You do not have add permission.
+{% if not exclude_actions %}
+  {% if may_add %}
+    <a href="{% url bread.add_url_name %}">{% trans "Add" %}</a>
+  {% elif debug %}
+    You do not have add permission.
+  {% endif %}
 {% endif %}

--- a/bread/templates/bread/includes/read.html
+++ b/bread/templates/bread/includes/read.html
@@ -7,21 +7,24 @@
     {{ field.label_tag }} {{ field.value }}
   {% endfor %}
 </div>
-{% if may_edit %}
-  <br/>
-  <a href="{% url bread.edit_url_name object.pk %}">{% trans "Edit" %}</a>
-{% elif debug %}
-  <br/>
-  You do not have edit permission.
-{% endif %}
 
-<br/>
-<a href="{% url bread.browse_url_name %}">{% trans "Back to list" %}</a>
+{% if not exclude_actions %}
+  {% if may_edit %}
+    <br/>
+    <a href="{% url bread.edit_url_name object.pk %}">{% trans "Edit" %}</a>
+  {% elif debug %}
+    <br/>
+    You do not have edit permission.
+  {% endif %}
 
-{% if may_delete %}
   <br/>
-  <a href="{% url bread.delete_url_name view.object.pk %}">{% trans "Delete" %}</a>
-{% elif debug %}
-  <br/>
-  You do not have delete permission.
+  <a href="{% url bread.browse_url_name %}">{% trans "Back to list" %}</a>
+
+  {% if may_delete %}
+    <br/>
+    <a href="{% url bread.delete_url_name view.object.pk %}">{% trans "Delete" %}</a>
+  {% elif debug %}
+    <br/>
+    You do not have delete permission.
+  {% endif %}
 {% endif %}


### PR DESCRIPTION
I figure that both browse and read will be common places to tack on model-specific actions.

FIxes #7 