### PR TITLE
Show verbose_name_plural to humans

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.pyc
 build
 dist
 .tox

--- a/bread/bread.py
+++ b/bread/bread.py
@@ -129,6 +129,7 @@ class BreadViewMixin(object):
         data = super(BreadViewMixin, self).get_context_data(**kwargs)
         # Include reference to the Bread object in template contexts
         data['bread'] = self.bread
+        data['model_meta'] = self.model._meta
         data['columns'] = self.bread.columns
         if data.get('is_paginated', False):
             page = data['page_obj']

--- a/bread/templates/bread/browse.html
+++ b/bread/templates/bread/browse.html
@@ -1,7 +1,7 @@
 {% extends base_template %}
 {% load i18n %}
 
-{% block title %}{% blocktrans with names=view.plural_name %}Browse {{ names }}{% endblocktrans %}{% endblock title %}
+{% block title %}{% blocktrans with names=model_meta.verbose_name_plural %}Browse {{ names }}{% endblocktrans %}{% endblock title %}
 
 {% block content %}
 


### PR DESCRIPTION
Currently we show `view.plural_name` in the title attribute of the Browse page. We also use that in other locations in libya_elections.

There are 2 problems with this.

1. `plural_name` is defined on the bread object, not the view object
2. `plural_name` is meant to be used in URLs, so it's not human-friendly.

Attached is a proposed solution: Include `model_meta` in the template and use `model_meta.verbose_name_plural` whenever we want human readable verbose names.

If this is a reasonable solution, then I will implement it in libya_elections as well.