### PR TITLE
Directly expose the Model meta options that template would need

### DIFF
--- a/bread/bread.py
+++ b/bread/bread.py
@@ -128,7 +128,10 @@ class BreadViewMixin(object):
         data = super(BreadViewMixin, self).get_context_data(**kwargs)
         # Include reference to the Bread object in template contexts
         data['bread'] = self.bread
-        data['model_meta'] = self.model._meta
+
+        # Provide references to useful Model Meta attributes
+        data['verbose_name'] = self.model._meta.verbose_name
+        data['verbose_name_plural'] = self.model._meta.verbose_name_plural
 
         # Template that the default bread templates should extend
         data['base_template'] = self.bread.base_template

--- a/bread/templates/bread/browse.html
+++ b/bread/templates/bread/browse.html
@@ -1,7 +1,7 @@
 {% extends base_template %}
 {% load i18n %}
 
-{% block title %}{% blocktrans with names=model_meta.verbose_name_plural %}Browse {{ names }}{% endblocktrans %}{% endblock title %}
+{% block title %}{% blocktrans with names=verbose_name_plural %}Browse {{ names }}{% endblocktrans %}{% endblock title %}
 
 {% block content %}
 


### PR DESCRIPTION
Only `verbose_name` and `verbose_name_plural` seem useful for a template. I'll
include this info in the template docs that I'm writing for #30 and then bump
the version in that PR after both are reviewed/merged.