### PR TITLE
add capfirst to label in label_value_read.html

### DIFF
--- a/bread/templates/bread/includes/label_value_read.html
+++ b/bread/templates/bread/includes/label_value_read.html
@@ -3,7 +3,7 @@
 <div id='fields'>
   {% for label, value in read_fields %}
     <div>
-      <label>{{ label }}</label>: <span class='value'>{{ value }}</span>
+      <label>{{ label|capfirst }}</label>: <span class='value'>{{ value }}</span>
     </div>
   {% endfor %}
 </div>

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -103,9 +103,9 @@ class BreadLabelValueReadTest(BreadTestCase):
         for expected in (
             "<label>Id</label>: <span class='value'>{}</span>".format(item.id),
             "<label>A Yellow Fruit</label>: <span class='value'>0</span>",
-            "<label>eman</label>: <span class='value'>edcba</span>",
+            "<label>Eman</label>: <span class='value'>edcba</span>",
             "<label>Foo</label>: <span class='value'>bar</span>",
-            "<label>context first key</label>: <span class='value'>{}</span>".format(key),
+            "<label>Context first key</label>: <span class='value'>{}</span>".format(key),
             "<label>Answer</label>: <span class='value'>42</span>",
                 ):
             self.assertContains(rsp, expected)


### PR DESCRIPTION
This makes this template behave more like `read.html` which also applies capfirst to labels