### PR TITLE
45 Fix filters disappearing when no results

### DIFF
--- a/bread/bread.py
+++ b/bread/bread.py
@@ -208,7 +208,7 @@ class BrowseView(BreadViewMixin, ListView):
         if q:
             data['q'] = q
         data['columns'] = self.columns
-        data['has_filter'] = bool(self.filter)
+        data['has_filter'] = self.filterset is not None
         data['has_search'] = bool(self.search_fields)
         if self.search_fields and self.search_terms:
             data['search_terms'] = self.search_terms


### PR DESCRIPTION
Set 'has_filter' based on whether a filterset has been
specified, not on the truthiness of view.filter.

Fixes #45