### PR TITLE
47 Fix searching for non-ASCII text

### DIFF
--- a/bread/bread.py
+++ b/bread/bread.py
@@ -123,7 +123,7 @@ class BreadViewMixin(object):
     def _get_new_url(self, **query_parms):
         """Return a new URL consisting of this request's URL, with any specified
         query parms updated or added"""
-        request_kwargs = dict(self.request.GET)
+        request_kwargs = self.request.GET.copy()
         request_kwargs.update(query_parms)
         return self.request.path + "?" + urlencode(request_kwargs, doseq=True)
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 from six.moves.http_client import OK
 
 from tests.base import BreadTestCase
@@ -79,3 +80,13 @@ class BreadSearchTestCase(BreadTestCase):
         objs = self.get_search_results(q='joe')
         obj_ids = [obj.id for obj in objs]
         self.assertEqual([self.joe.id], obj_ids)
+
+    def test_nonascii_search(self):
+        # This was failing if we were also paginating
+        BreadTestModelFactory(name=u'قمر')
+        BreadTestModelFactory(name=u'قمر')
+        try:
+            self.bread.browse_view.paginate_by = 1
+            self.get_search_results(q=u'قمر')
+        finally:
+            self.bread.browse_view.paginate_by = None


### PR DESCRIPTION
We were converting the request.GET object to a dict,
updating it, and passing it to urlencode. Apparently
if we didn't change the type, urlencode could handle it
better.

Fixes #47