### PR TITLE
Use the right form enctype

### DIFF
--- a/bread/templates/bread/includes/edit.html
+++ b/bread/templates/bread/includes/edit.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 
-<form method="POST">
+<form method="POST"{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
   {% csrf_token %}
     {% if form.non_field_errors %}
       <div class="control-group">


### PR DESCRIPTION
On the edit page, if uploading files, form needs the proper
enctype or it won't work.