### PR TITLE
55 Fix setting form_class on specific views

### DIFF
--- a/bread/bread.py
+++ b/bread/bread.py
@@ -563,7 +563,6 @@ class Bread(object):
         return self.read_view.as_view(
             bread=self,
             model=self.model,
-            form_class=self.form_class,
         )
 
     #####
@@ -576,7 +575,6 @@ class Bread(object):
         return self.edit_view.as_view(
             bread=self,
             model=self.model,
-            form_class=self.form_class,
         )
 
     #####
@@ -589,7 +587,6 @@ class Bread(object):
         return self.add_view.as_view(
             bread=self,
             model=self.model,
-            form_class=self.form_class,
         )
 
     #####

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -1,12 +1,13 @@
 from six.moves.http_client import OK, METHOD_NOT_ALLOWED
 
 from django.core.urlresolvers import reverse
+from django import forms
 from django.http import Http404
 
+from bread.bread import LabelValueReadView, Bread, ReadView
 from .base import BreadTestCase
-from .models import BreadLabelValueTestModel
+from .models import BreadLabelValueTestModel, BreadTestModel
 from .factories import BreadLabelValueTestModelFactory
-from bread.bread import LabelValueReadView, Bread
 
 
 class BreadReadTest(BreadTestCase):
@@ -110,3 +111,28 @@ class BreadLabelValueReadTest(BreadTestCase):
             "<label>Answer</label>: <span class='value'>42</span>",
                 ):
             self.assertContains(rsp, expected)
+
+    def test_setting_form_class(self):
+        class DummyForm(forms.Form):
+            pass
+
+        glob = {}
+
+        class TestView(ReadView):
+            form_class = DummyForm
+
+            # To get hold of a reference to the actual view object created by
+            # bread, use a fake dispatch method that saves 'self' into a
+            # dictionary we can access in the test.
+            def dispatch(self, *args, **kwargs):
+                glob['view_object'] = self
+
+        class BreadTest(Bread):
+            model = BreadTestModel
+            read_view = TestView
+
+        bread = BreadTest()
+        view_function = bread.get_read_view()
+        # Call the view function to invoke dispatch so we can get to the view itself
+        view_function(None, None, None)
+        self.assertEqual(DummyForm, glob['view_object'].form_class)


### PR DESCRIPTION
The bread class was overriding specific views' form_class
attribute with its own.

Fixes #55