### PR TITLE
58 Handle exception from related object does not exist

### DIFF
--- a/bread/templatetags/bread_tags.py
+++ b/bread/templatetags/bread_tags.py
@@ -1,6 +1,7 @@
 import logging
 
 from django import template
+from django.core.exceptions import ObjectDoesNotExist
 
 from bread.utils import get_model_field
 
@@ -19,5 +20,7 @@ def getter(value, arg):
     """
     try:
         return get_model_field(value, arg)
+    except ObjectDoesNotExist:
+        pass
     except:
         logger.exception("Something blew up: %s|getter:%s" % (value, arg))

--- a/bread/utils.py
+++ b/bread/utils.py
@@ -153,7 +153,7 @@ def validate_fieldspec(model, spec):
     else:
         # It's a field
         # Is it a key?
-        if field.rel:
+        if getattr(field, 'rel', False):
             # Yes, refers to another model
             if rest_of_spec:
                 # Recurse!

--- a/tests/base.py
+++ b/tests/base.py
@@ -35,12 +35,14 @@ class BreadTestCase(TestCase):
             columns = [
                 ('Name', 'name'),
                 ('Text', 'other__text'),
+                ('Model1', 'model1',)
                 ]
 
         class BrowseClass(BrowseView):
             columns = [
                 ('Name', 'name'),
-                ('Text', 'other__text')
+                ('Text', 'other__text'),
+                ('Model1', 'model1',)
             ]
 
         class BreadTestClass(Bread):

--- a/tests/models.py
+++ b/tests/models.py
@@ -25,6 +25,10 @@ class BreadLabelValueTestModel(models.Model):
 
 class BreadTestModel2(models.Model):
     text = models.CharField(max_length=20)
+    label_model = models.OneToOneField(BreadLabelValueTestModel, null=True,
+                                       related_name='model2')
+    model1 = models.OneToOneField('BreadTestModel', null=True,
+                                  related_name='model1')
 
     def get_text(self):
         return self.text

--- a/tests/test_browse.py
+++ b/tests/test_browse.py
@@ -1,10 +1,11 @@
+import six
 from six.moves.http_client import OK, METHOD_NOT_ALLOWED, BAD_REQUEST
 
 from django.core.urlresolvers import reverse
-try:
-    # Python 3
+
+if six.PY3:
     from unittest.mock import patch
-except ImportError:
+else:
     from mock import patch
 
 from bread.bread import BrowseView

--- a/tests/test_browse.py
+++ b/tests/test_browse.py
@@ -1,6 +1,11 @@
 from six.moves.http_client import OK, METHOD_NOT_ALLOWED, BAD_REQUEST
 
 from django.core.urlresolvers import reverse
+try:
+    # Python 3
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 from bread.bread import BrowseView
 from .base import BreadTestCase
@@ -8,7 +13,8 @@ from .factories import BreadTestModelFactory
 
 
 class BreadBrowseTest(BreadTestCase):
-    def test_get(self):
+    @patch('bread.templatetags.bread_tags.logger')
+    def test_get(self, mock_logger):
         self.set_urls(self.bread)
         items = [BreadTestModelFactory() for __ in range(5)]
         self.give_permission('browse')
@@ -22,6 +28,8 @@ class BreadBrowseTest(BreadTestCase):
         body = rsp.content.decode('utf-8')
         for item in items:
             self.assertIn(item.name, body)
+        # No exceptions logged
+        self.assertFalse(mock_logger.exception.called)
 
     def test_get_empty_list(self):
         self.set_urls(self.bread)
@@ -42,7 +50,8 @@ class BreadBrowseTest(BreadTestCase):
         rsp = self.bread.get_browse_view()(request)
         self.assertEqual(METHOD_NOT_ALLOWED, rsp.status_code)
 
-    def test_sort_all_ascending(self):
+    @patch('bread.templatetags.bread_tags.logger')
+    def test_sort_all_ascending(self, mock_logger):
         self.set_urls(self.bread)
         BreadTestModelFactory(name='999', other__text='012')
         BreadTestModelFactory(name='555', other__text='333')
@@ -61,8 +70,11 @@ class BreadBrowseTest(BreadTestCase):
             sortB = (results[i+1].name, results[i+1].other.text)
             self.assertLessEqual(sortA, sortB)
             i += 1
+        # No exceptions logged
+        self.assertFalse(mock_logger.exception.called)
 
-    def test_sort_all_descending(self):
+    @patch('bread.templatetags.bread_tags.logger')
+    def test_sort_all_descending(self, mock_logger):
         self.set_urls(self.bread)
         BreadTestModelFactory(name='999', other__text='012')
         BreadTestModelFactory(name='555', other__text='333')
@@ -81,6 +93,8 @@ class BreadBrowseTest(BreadTestCase):
             sortB = (results[i+1].name, results[i+1].other.text)
             self.assertGreaterEqual(sortA, sortB)
             i += 1
+        # No exceptions logged
+        self.assertFalse(mock_logger.exception.called)
 
     def test_sort_first_ascending(self):
         self.set_urls(self.bread)
@@ -165,7 +179,8 @@ class BreadBrowseTest(BreadTestCase):
         self.assertEqual(d, results[3])
         self.assertEqual(e, results[4])
 
-    def test_sort_second_field_ascending_first_descending(self):
+    @patch('bread.templatetags.bread_tags.logger')
+    def test_sort_second_field_ascending_first_descending(self, mock_logger):
         self.set_urls(self.bread)
         d = BreadTestModelFactory(name='1', other__text='111')
         a = BreadTestModelFactory(name='999', other__text='000')
@@ -185,6 +200,8 @@ class BreadBrowseTest(BreadTestCase):
         self.assertEqual(c, results[2])
         self.assertEqual(d, results[3])
         self.assertEqual(e, results[4])
+        # No exceptions logged
+        self.assertFalse(mock_logger.exception.called)
 
 
 class BadSortTest(BreadTestCase):

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -68,6 +68,7 @@ class BreadLabelValueReadTest(BreadTestCase):
                 # Mode 4 below
                 ('context first key', lambda context_data: sorted(context_data.keys())[0]),
                 ('Answer', 42),                      # Mode 5
+                ('Model2', 'model2'),                # Back through related name for one2one field
             ]
 
         class BreadTestClass(Bread):

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 downloadcache = {toxworkdir}/_download/
-envlist = {py27,py34}-django{17,18}, docs, pep8
+envlist = {py27,py34}-django{17,18}, docs, {py27,py34}-pep8
 whitelist_externals = /usr/bin/make
 
 [testenv]
@@ -15,6 +15,7 @@ deps =
     django-vanilla-views>=1.0.3,<2.0
     django17: Django>=1.7,<1.8
     django18: Django>=1.8,<1.9
+    py27: mock==1.0.1
 commands = {envpython} runtests.py {posargs}
 
 [testenv:docs]
@@ -23,7 +24,12 @@ deps = sphinx
 changedir = docs
 commands = /usr/bin/make html
 
-[testenv:pep8]
+[testenv:py27-pep8]
 basepython = python2.7
+deps = flake8
+commands = flake8
+
+[testenv:py34-pep8]
+basepython = python3.4
 deps = flake8
 commands = flake8


### PR DESCRIPTION
There are some cases in Django where referencing a model field
that is a link to another model that doesn't exist will raise a
RelatedObjectDoesNotExist exception. We were catching that in
our template tag, but logging an exception. Depending on the logging
configuration, this could result in administrators getting an error
email from the server.

Fix by silently ignoring these exceptions, and just returning None
(which is what you might have expected Django to do anyway).

Fixes #58