### PR TITLE
Use Django 2.1's "view_{model_name}" permission

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,10 +10,25 @@ pagination, and more.
 This is relatively stable. We're using it in production and have attempted
 to document the important parts, but feedback is welcome.
 
+Breaking change in 0.7.0
+------------------------
+
+Version 0.7.0 includes a breaking change! If you're using the default
+view permissions, before upgrading, make sure you've
+migrated your users and groups that have "read_{model_name}"
+permissions to also have "view_{model_name}".  From 0.7.0 on, that's the
+default permission a user needs to use the read views, because it's become the
+standard Django permission for read-only access since Django 2.1.
+
+If you're still on Django 2.0, don't upgrade django-bread until you
+can get to at least Django 2.1. (Hopefully that's not the case, since
+Django 2.0 has been out of support since April 1, 2019.)
+
+
 Supported versions
 ------------------
 
-Django: 2.0, 2.1, 2.2
+Django: 2.1, 2.2
 Python: 3.5, 3.6, 3.7
 
 For Python 2.7 and/or Django 1.11 support, the 0.5 release series is identical (features-wise)

--- a/README.rst
+++ b/README.rst
@@ -10,13 +10,13 @@ pagination, and more.
 This is relatively stable. We're using it in production and have attempted
 to document the important parts, but feedback is welcome.
 
-Breaking change in 0.7.0
+Breaking change in 1.0.0
 ------------------------
 
-Version 0.7.0 includes a breaking change! If you're using the default
+Version 1.0.0 includes a breaking change! If you're using the default
 view permissions, before upgrading, make sure you've
 migrated your users and groups that have "read_{model_name}"
-permissions to also have "view_{model_name}".  From 0.7.0 on, that's the
+permissions to also have "view_{model_name}".  From 1.0.0 on, that's the
 default permission a user needs to use the read views, because it's become the
 standard Django permission for read-only access since Django 2.1.
 

--- a/bread/__init__.py
+++ b/bread/__init__.py
@@ -1,1 +1,1 @@
-VERSION = '0.6.0'
+VERSION = '0.7.0'

--- a/bread/__init__.py
+++ b/bread/__init__.py
@@ -1,1 +1,1 @@
-VERSION = '0.7.0'
+VERSION = '1.0.0'

--- a/bread/bread.py
+++ b/bread/bread.py
@@ -345,7 +345,7 @@ class ReadView(BreadViewMixin, DetailView):
     we can iterate over in the template to display it if we don't want
     to make a custom template for this model.
     """
-    perm_name = 'read'  # Not a default Django permission
+    perm_name = 'view'  # Default Django permission
     template_name_suffix = '_read'
 
     def get_context_data(self, **kwargs):

--- a/bread/migrations/0001_initial.py
+++ b/bread/migrations/0001_initial.py
@@ -16,7 +16,7 @@ class Migration(migrations.Migration):
             ],
             options={
                 'ordering': ['name'],
-                'permissions': [('read_breadtestmodel', 'can read BreadTestModel'), ('browse_breadtestmodel', 'can browse BreadTestModel')],
+                'permissions': [('browse_breadtestmodel', 'can browse BreadTestModel')],
             },
             bases=(models.Model,),
         ),

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -3,6 +3,19 @@
 Change Log
 ==========
 
+0.7.0 - Oct 20, 2020
+-------------------
+
+* BREAKING CHANGE: by default, read views now need Django's
+  "view_<modelname>" permission instead of the nonstandard
+  "read_<modelname>".
+* Drop support for Django 2.0
+
+Supported versions in this release are:
+
+Django: 2.1, 2.2
+Python: 3.5, 3.6, 3.7
+
 0.6.0 - Apr 19, 2019
 --------------------
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -3,7 +3,7 @@
 Change Log
 ==========
 
-0.7.0 - Oct 20, 2020
+1.0.0 - Oct 20, 2020
 -------------------
 
 * BREAKING CHANGE: by default, read views now need Django's

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -117,11 +117,15 @@ These can be set on any individual view class.
 
 perm_name
     The base permission name needed to access the view. Defaults are
-    'browse', 'read', 'edit', 'add', and 'delete'.  Then `_` and the
+    'browse', 'view', 'edit', 'add', and 'delete'.  Then `_` and the
     lowercased model name are appended to get the complete permission name
     that a user must have to access the view. E.g. if your model is
     `MyModel` and you leave the default `perm_name` on the browse view,
     the user must have `browse_mymodel` permission.
+
+    (Note that the permission for the "read" view is "view", not "read".
+    It's a little confusing in this context, but "view" is what Django
+    decided on for its standard read-only permission.)
 
 template_name_suffix
     The default string that the template this view uses will end with.
@@ -289,7 +293,7 @@ Alternate read view configuration
 ---------------------------------
 
 The default read view uses a form to describe which fields to display. If
-you would rather have more flexibilty, subclass `bread.LabelValueReadView`
+you would rather have more flexibility, subclass `bread.LabelValueReadView`
 and set these parameters.
 
 LabelValueReadView is a subclass of ReadView.

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Topic :: Software Development :: Libraries :: Python Modules',
-        'Framework :: Django :: 2.0',
         'Framework :: Django :: 2.1',
         'Framework :: Django :: 2.2',
     ],

--- a/tests/models.py
+++ b/tests/models.py
@@ -52,7 +52,6 @@ class BreadTestModel(models.Model):
             '-age',  # If same name, sort oldest first
         ]
         permissions = [
-            ('read_breadtestmodel', 'can read BreadTestModel'),
             ('browse_breadtestmodel', 'can browse BreadTestModel'),
         ]
 

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -12,7 +12,7 @@ class BreadReadTest(BreadTestCase):
     def setUp(self):
         super(BreadReadTest, self).setUp()
         self.urlconf = 'bread.tests.test_read'
-        self.give_permission('read')
+        self.give_permission('view')
         self.set_urls(self.bread)
 
     def test_read(self):
@@ -42,7 +42,7 @@ class BreadReadTest(BreadTestCase):
 
     def test_post(self):
         self.set_urls(self.bread)
-        self.give_permission('read')
+        self.give_permission('view')
         item = self.model_factory()
         url = reverse(self.bread.get_url_name('read'), kwargs={'pk': item.pk})
         request = self.request_factory.post(url)
@@ -81,7 +81,7 @@ class BreadLabelValueReadTest(BreadTestCase):
         self.model_factory = BreadLabelValueTestModelFactory
 
         self.urlconf = 'bread.tests.test_read'
-        self.give_permission('read')
+        self.give_permission('view')
         self.set_urls(self.bread)
 
     def test_read(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 downloadcache = {toxworkdir}/_download/
-envlist = {py35,py36,py37}-django{20,21,22}, docs, py37-pep8
+envlist = {py35,py36,py37}-django{21,22}, docs, py37-pep8
 whitelist_externals = /usr/bin/make
 
 [testenv]
@@ -10,7 +10,6 @@ basepython =
     py37: python3.7
 deps =
     factory_boy==2.3.1
-    django20: Django>=2.0,<2.1
     django21: Django>=2.1,<2.2
     django22: Django>=2.2,<3.0
 # -Wmodule so we at least see deprecation warnings


### PR DESCRIPTION
Django 2.1 added a standard permission for read-only access,
and it's named "view_*" instead of the non-standard "read_*"
we've been using here. Change the default view permission on
the read-only view to need "view_*" instead of "read_*".
This could be a breaking change, so add a warning to the README
about it.