### PR TITLE
v1.0.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ dist: xenial
 language: python
 
 python:
-  - "3.5"
-  - "3.6"
   - "3.7"
+  - "3.8"
+  - "3.9"
 
 install:
   - pip install tox-travis

--- a/README.rst
+++ b/README.rst
@@ -28,8 +28,8 @@ Django 2.0 has been out of support since April 1, 2019.)
 Supported versions
 ------------------
 
-Django: 2.1, 2.2
-Python: 3.5, 3.6, 3.7
+Django: 2.2, 3.0, 3.1
+Python: 3.7, 3.8, 3.9
 
 For Python 2.7 and/or Django 1.11 support, the 0.5 release series is identical (features-wise)
 to 0.6 and is available on PyPI: https://pypi.org/project/django-bread/#history

--- a/bread/__init__.py
+++ b/bread/__init__.py
@@ -1,1 +1,1 @@
-VERSION = '1.0.0'
+VERSION = '1.0.1'

--- a/bread/bread.py
+++ b/bread/bread.py
@@ -9,9 +9,10 @@ from django.contrib.auth import REDIRECT_FIELD_NAME
 from django.contrib.auth.models import Permission
 from django.contrib.auth.views import redirect_to_login
 from django.contrib.contenttypes.models import ContentType
-from django.core.exceptions import ImproperlyConfigured, PermissionDenied, FieldError
+from django.core.exceptions import (
+    ImproperlyConfigured, PermissionDenied, FieldError, EmptyResultSet
+)
 from django.db.models import Model, Q
-from django.db.models.sql import EmptyResultSet
 from django.forms.models import modelform_factory
 from django.http.response import HttpResponseBadRequest
 from django.urls import reverse_lazy, path

--- a/bread/utils.py
+++ b/bread/utils.py
@@ -30,9 +30,8 @@ work.
 """
 import inspect
 
-from django.core.exceptions import ValidationError
+from django.core.exceptions import ValidationError, FieldDoesNotExist
 from django.db.models import Model
-from django.db.models.fields import FieldDoesNotExist
 from django.db.models.fields.related import RelatedField
 
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -3,8 +3,22 @@
 Change Log
 ==========
 
-1.0.0 - Oct 20, 2020
+1.0.1 - Dec 2, 2020
 -------------------
+
+* Drop specific version dependencies in setup.py for
+  django-filter and django-vanilla-views
+* Update supported versions of Python and Django,
+  dropping Django 2.1 and adding 3.0 and 3.1,
+  and dropping Python 3.5 and 3.6 and adding 3.8 and 3.9.
+
+Supported versions in this release are:
+
+Django: 2.2, 3.0, 3.1
+Python: 3.7, 3.8, 3.9
+
+1.0.0 - Oct 20, 2020
+--------------------
 
 * BREAKING CHANGE: by default, read views now need Django's
   "view_<modelname>" permission instead of the nonstandard

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,8 @@ setup(
     description='Helper for building BREAD interfaces',
     include_package_data=True,
     install_requires=[
-        'django-filter>2,<2.2.0',
-        'django-vanilla-views>=1.0.3,<2.0',
+        'django-filter',
+        'django-vanilla-views',
     ],
     long_description=open('README.rst').read(),
     classifiers=[
@@ -22,12 +22,13 @@ setup(
         'License :: OSI Approved :: Apache Software License',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Topic :: Software Development :: Libraries :: Python Modules',
-        'Framework :: Django :: 2.1',
         'Framework :: Django :: 2.2',
+        'Framework :: Django :: 3.0',
+        'Framework :: Django :: 3.1',
     ],
     zip_safe=False,  # because we're including media that Django needs
 )

--- a/tests/models.py
+++ b/tests/models.py
@@ -10,7 +10,6 @@ to the tests, and maybe get fancier with different test models
 for different tests.
 """
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 
 class BreadLabelValueTestModel(models.Model):
@@ -37,7 +36,6 @@ class BreadTestModel2(models.Model):
         return self.text
 
 
-@python_2_unicode_compatible
 class BreadTestModel(models.Model):
     name = models.CharField(max_length=10)
     age = models.IntegerField()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,4 @@
-from django.core.exceptions import ValidationError
-from django.db.models.fields import FieldDoesNotExist
+from django.core.exceptions import ValidationError, FieldDoesNotExist
 from django.test import TestCase
 
 from bread.utils import get_model_field, validate_fieldspec, has_required_args, get_verbose_name

--- a/tox.ini
+++ b/tox.ini
@@ -1,27 +1,28 @@
 [tox]
 downloadcache = {toxworkdir}/_download/
-envlist = {py35,py36,py37}-django{21,22}, docs, py37-pep8
+envlist = {py37,py38,py39}-django{22,30,31}, docs, py38-pep8
 whitelist_externals = /usr/bin/make
 
 [testenv]
 basepython =
-    py35: python3.5
-    py36: python3.6
     py37: python3.7
+    py38: python3.8
+    py39: python3.9
 deps =
     factory_boy==2.3.1
-    django21: Django>=2.1,<2.2
     django22: Django>=2.2,<3.0
+    django30: DJango>=3.0,<3.1
+    django31: DJango>=3.1,<3.2
 # -Wmodule so we at least see deprecation warnings
 commands = {envpython} -Wmodule runtests.py {posargs}
 
 [testenv:docs]
-basepython = python3.7
+basepython = python3.8
 deps = sphinx
 changedir = docs
 commands = /usr/bin/make html
 
-[testenv:py37-pep8]
-basepython = python3.7
+[testenv:py38-pep8]
+basepython = python3.8
 deps = flake8
 commands = flake8


### PR DESCRIPTION
* Drop specific version dependencies in setup.py for
  django-filter and django-vanilla-views
* Update supported versions of Python and Django,
  dropping Django 2.1 and adding 3.0 and 3.1,
  and dropping Python 3.5 and 3.6 and adding 3.8 and 3.9.