### PR TITLE
support traversing reverse OneToOneRel fields

### DIFF
--- a/bread/utils.py
+++ b/bread/utils.py
@@ -33,6 +33,7 @@ import inspect
 from django.core.exceptions import FieldDoesNotExist, ValidationError
 from django.db.models import Model
 from django.db.models.fields.related import RelatedField
+from django.db.models.fields.reverse_related import OneToOneRel
 
 
 def get_value_or_result(model_instance, attribute_name):
@@ -158,7 +159,7 @@ def validate_fieldspec(model, spec):
     else:
         # It's a field
         # Is it a key?
-        if isinstance(field, RelatedField):
+        if isinstance(field, RelatedField) or isinstance(field, OneToOneRel):
             # Yes, refers to another model
             if rest_of_spec:
                 # Recurse!

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -135,6 +135,9 @@ class ValidateFieldspecTestCase(TestCase):
         with self.assertRaises(ValidationError):
             validate_fieldspec(BreadTestModel, "other__petunias")
 
+    def test_reverse_one_to_one_rel(self):
+        validate_fieldspec(BreadLabelValueTestModel, "model2__text")
+
 
 class GetVerboseNameTest(TestCase):
     """Exercise get_verbose_name()"""


### PR DESCRIPTION
It turns out traversing reverse `OneToOneRel` fields works just fine, but the current code prevents it. This PR relaxes `validate_fieldspec()` to support traversing reverse `OneToOneRel` fields in bread view definitions.