### PR TITLE
HTML escape 400 error page content

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 22.3.0
     hooks:
       - id: black
 

--- a/bread/bread.py
+++ b/bread/bread.py
@@ -19,6 +19,7 @@ from django.db.models import Model, Q
 from django.forms.models import modelform_factory
 from django.http.response import HttpResponseBadRequest
 from django.urls import path, reverse_lazy
+from django.utils.html import escape
 from vanilla import CreateView, DeleteView, DetailView, ListView, UpdateView
 
 from .utils import get_verbose_name, validate_fieldspec
@@ -114,7 +115,7 @@ class BreadViewMixin(object):
         try:
             return super(BreadViewMixin, self).dispatch(request, *args, **kwargs)
         except Http400 as e:
-            return HttpResponseBadRequest(content=e.msg.encode("utf-8"))
+            return HttpResponseBadRequest(content=escape(e.msg).encode("utf-8"))
 
     def get_template_names(self):
         """Return Django Vanilla templates (app-specific), then

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -47,9 +47,9 @@ source_suffix = ".rst"
 master_doc = "index"
 
 # General information about the project.
-project = u"Django Bread"
-copyright = u"2015, Caktus Consulting, LLC"
-author = u"Caktus Consulting, LLC"
+project = "Django Bread"
+copyright = "2015, Caktus Consulting, LLC"
+author = "Caktus Consulting, LLC"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -223,8 +223,8 @@ latex_documents = [
     (
         master_doc,
         "DjangoBread.tex",
-        u"Django Bread Documentation",
-        u"Caktus Consulting, LLC",
+        "Django Bread Documentation",
+        "Caktus Consulting, LLC",
         "manual",
     ),
 ]
@@ -254,7 +254,7 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [(master_doc, "djangobread", u"Django Bread Documentation", [author], 1)]
+man_pages = [(master_doc, "djangobread", "Django Bread Documentation", [author], 1)]
 
 # If true, show URL addresses after external links.
 # man_show_urls = False
@@ -269,7 +269,7 @@ texinfo_documents = [
     (
         master_doc,
         "DjangoBread",
-        u"Django Bread Documentation",
+        "Django Bread Documentation",
         author,
         "DjangoBread",
         "One line description of project.",

--- a/tests/test_browse.py
+++ b/tests/test_browse.py
@@ -259,6 +259,17 @@ class BadSortTest(BreadTestCase):
         rsp = self.bread.get_browse_view()(request)
         self.assertEqual(400, rsp.status_code)
 
+    def test_html_injection(self):
+        """Bad user queryparam input should be escaped in error messages."""
+        self.set_urls(self.bread)
+        BreadTestModelFactory(name="1", other__text="111")
+        self.give_permission("browse")
+        url = reverse(self.bread.get_url_name("browse")) + "?o=<h1>hello</h1>"
+        request = self.request_factory.get(url)
+        request.user = self.user
+        rsp = self.bread.get_browse_view()(request)
+        self.assertNotContains(rsp, "<h1>hello</h1>", status_code=400, html=True)
+
 
 class NotDisablingSortTest(BreadTestCase):
     class BrowseClass(BrowseView):

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -81,10 +81,10 @@ class BreadSearchTestCase(BreadTestCase):
 
     def test_nonascii_search(self):
         # This was failing if we were also paginating
-        BreadTestModelFactory(name=u"قمر")
-        BreadTestModelFactory(name=u"قمر")
+        BreadTestModelFactory(name="قمر")
+        BreadTestModelFactory(name="قمر")
         try:
             self.bread.browse_view.paginate_by = 1
-            self.get_search_results(q=u"قمر")
+            self.get_search_results(q="قمر")
         finally:
             self.bread.browse_view.paginate_by = None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -173,7 +173,7 @@ class GetVerboseNameTest(TestCase):
         """Ensure FieldDoesNotExist is raised no matter what trash is passed as the field name"""
         for field_name in (
             "kjasfhkjdh",
-            u"sfasfda",
+            "sfasfda",
             None,
             42,
             False,


### PR DESCRIPTION
## Issue https://github.com/caktus/django_bread/issues/78

## Changes
- escape 400 error pages before rendering to prevent HTML injection
- update `black` version in pre-commit and format all files (CI failed with the old version)