### PR TITLE
Allow annotations in browse views

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.3.0
+    rev: v4.2.0
     hooks:
       - id: check-added-large-files
       - id: check-case-conflict
@@ -20,11 +20,11 @@ repos:
       - id: black
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.6.4
+    rev: 5.10.1
     hooks:
       - id: isort
 
   - repo: https://gitlab.com/pycqa/flake8
-    rev: master
+    rev: 3.9.2
     hooks:
       - id: flake8


### PR DESCRIPTION
## Issue https://github.com/caktus/django_bread/issues/80

## Changes

- Add an `is_annotation` class attribute that end users use to mark a column as containing an annotation
```python
class BrowseClass(BrowseView):
    queryset = BreadTestModel.objects.annotate(loud_name=Upper("name"))
    columns = [
        ("Name", "name"),
        ("Loud Name", "loud_name", BrowseView.is_annotation, "loud_name"),
    ]
```
- When a column is marked as `is_annotation`, do not assert that it can be found on the model class (annotations aren't present until a query is made)
- When determining if a column can be sorted on, instead of `self.model.objects` use `self.get_queryset()` which will include any annotations