### PR TITLE
Django 4.x Support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         # tox-gh-actions will only run the tox environments which match the currently
         # running python-version. See [gh-actions] in tox.ini for the mapping
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9, 3.10]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ _build
 .coverage
 .envrc
 .direnv
+.vscode/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,9 +28,3 @@ repos:
     rev: 6.0.0
     hooks:
       - id: flake8
-
-  - repo: https://github.com/adamchainz/django-upgrade
-    rev: "1.14.0"
-    hooks:
-      - id: django-upgrade
-        args: [--target-version, "4.2"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,3 +28,9 @@ repos:
     rev: 6.0.0
     hooks:
       - id: flake8
+
+  - repo: https://github.com/adamchainz/django-upgrade
+    rev: "1.14.0"
+    hooks:
+      - id: django-upgrade
+        args: [--target-version, "4.2"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
+    rev: v4.4.0
     hooks:
       - id: check-added-large-files
       - id: check-case-conflict
@@ -15,16 +15,16 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 23.7.0
     hooks:
       - id: black
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
 
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.9.2
+  - repo: https://github.com/PyCQA/flake8
+    rev: 6.0.0
     hooks:
       - id: flake8

--- a/README.rst
+++ b/README.rst
@@ -28,8 +28,8 @@ Django 2.0 has been out of support since April 1, 2019.)
 Supported versions
 ------------------
 
-Django: 2.2, 3.2
-Python: 3.7, 3.8, 3.9, 3.10
+Django: 3.2, 4.2
+Python: 3.8, 3.9, 3.10
 
 For Python 2.7 and/or Django 1.11 support, the 0.5 release series is identical (features-wise)
 to 0.6 and is available on PyPI: https://pypi.org/project/django-bread/#history

--- a/bread/bread.py
+++ b/bread/bread.py
@@ -372,9 +372,9 @@ class BrowseView(BreadViewMixin, ListView):
                             use_distinct = True
                             break
                     except ImportError:
-                        from django.contrib.admin.utils import lookup_spawns_duplicates
+                        from django.contrib.admin.utils import lookup_needs_distinct
 
-                        if lookup_spawns_duplicates(opts, search_spec):
+                        if lookup_needs_distinct(opts, search_spec):
                             use_distinct = True
                             break
 

--- a/bread/bread.py
+++ b/bread/bread.py
@@ -366,15 +366,15 @@ class BrowseView(BreadViewMixin, ListView):
                     # to lookup_spawns_duplicates() in Django 4.0
                     # https://docs.djangoproject.com/en/4.2/releases/4.0/#:~:text=The%20undocumented%20django.contrib.admin.utils.lookup_needs_distinct()%20function%20is%20renamed%20to%20lookup_spawns_duplicates().
                     try:
-                        from django.contrib.admin.utils import lookup_needs_distinct
-
-                        if lookup_needs_distinct(opts, search_spec):
-                            use_distinct = True
-                            break
-                    except ImportError:
                         from django.contrib.admin.utils import lookup_spawns_duplicates
 
                         if lookup_spawns_duplicates(opts, search_spec):
+                            use_distinct = True
+                            break
+                    except ImportError:
+                        from django.contrib.admin.utils import lookup_needs_distinct
+
+                        if lookup_needs_distinct(opts, search_spec):
                             use_distinct = True
                             break
 

--- a/bread/bread.py
+++ b/bread/bread.py
@@ -372,9 +372,9 @@ class BrowseView(BreadViewMixin, ListView):
                             use_distinct = True
                             break
                     except ImportError:
-                        from django.contrib.admin.utils import lookup_needs_distinct
+                        from django.contrib.admin.utils import lookup_spawns_duplicates
 
-                        if lookup_needs_distinct(opts, search_spec):
+                        if lookup_spawns_duplicates(opts, search_spec):
                             use_distinct = True
                             break
 

--- a/bread/migrations/0001_initial.py
+++ b/bread/migrations/0001_initial.py
@@ -3,7 +3,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = []
 
     operations = [

--- a/bread/migrations/0002_delete_breadtestmodel.py
+++ b/bread/migrations/0002_delete_breadtestmodel.py
@@ -3,7 +3,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("bread", "0001_initial"),
     ]

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
 . # <- install ourselves
 coverage
 django>=3.2,<4.0
-factory_boy==2.3.1
+factory_boy==3.2.1
 flake8
 pre-commit
 sphinx

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,7 +48,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "Django Bread"
-copyright = "2015, Caktus Consulting, LLC"
+copyright = "2015-2023, Caktus Consulting, LLC"
 author = "Caktus Consulting, LLC"
 
 # The version info for the project you're documenting, acts as replacement for

--- a/setup.py
+++ b/setup.py
@@ -28,9 +28,12 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Topic :: Software Development :: Libraries :: Python Modules",
-        "Framework :: Django :: 2.2",
         "Framework :: Django :: 3.2",
+        "Framework :: Django :: 4.0",
+        "Framework :: Django :: 4.1",
+        "Framework :: Django :: 4.2",
     ],
     zip_safe=False,  # because we're including media that Django needs
 )

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Framework :: Django :: 3.2",
-        "Framework :: Django :: 4.0",
         "Framework :: Django :: 4.1",
         "Framework :: Django :: 4.2",
     ],

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,24 +1,26 @@
 import factory
-import factory.fuzzy
 
 from .models import BreadLabelValueTestModel, BreadTestModel, BreadTestModel2
 
 
-class BreadTestModel2Factory(factory.DjangoModelFactory):
-    FACTORY_FOR = BreadTestModel2
+class BreadTestModel2Factory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = BreadTestModel2
 
-    text = factory.fuzzy.FuzzyText(length=10)
+    text = factory.Faker("text", max_nb_chars=10)
 
 
-class BreadTestModelFactory(factory.DjangoModelFactory):
-    FACTORY_FOR = BreadTestModel
+class BreadTestModelFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = BreadTestModel
 
-    name = factory.fuzzy.FuzzyText(length=10)
-    age = factory.fuzzy.FuzzyInteger(low=1, high=99)
+    name = factory.Faker("name")
+    age = factory.Faker("pyint", min_value=0, max_value=99)
     other = factory.SubFactory(BreadTestModel2Factory)
 
 
-class BreadLabelValueTestModelFactory(factory.DjangoModelFactory):
-    FACTORY_FOR = BreadLabelValueTestModel
+class BreadLabelValueTestModelFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = BreadLabelValueTestModel
 
-    name = factory.fuzzy.FuzzyText(length=10)
+    name = factory.Faker("name")

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,8 @@
 [tox]
-envlist = {py37,py38,py39}-django{22,32},py310-django32
+envlist = {py38,py39,py310}-django{3.2,4.0,4.1,4.2},py310-django42
 
 [gh-actions]
 python =
-    3.7: py37
     3.8: py38
     3.9: py39
     3.10: py310
@@ -11,6 +10,8 @@ python =
 [testenv]
 deps =
     factory_boy==2.3.1
-    django22: Django>=2.2,<3.0
     django32: Django>=3.2,<4.0
+    django40: Django>=4.0
+    django42: Django>=4.1
+    django42: Django>=4.2
 commands = python -Wmodule runtests.py

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py38,py39,py310}-django{32,40,41,42}
+envlist = {py38,py39,py310}-django{32,41,42}
 
 [gh-actions]
 python =
@@ -11,7 +11,6 @@ python =
 deps =
     factory_boy==3.2.1
     django32: Django>=3.2,<4.0
-    django40: Django>=4.0,<4.1
     django41: Django>=4.1,<4.2
     django42: Django>=4.2,<5.0
 commands = python -Wmodule runtests.py

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ python =
 
 [testenv]
 deps =
-    factory_boy==2.3.1
+    factory_boy==3.2.1
     django32: Django>=3.2,<4.0
     django40: Django>=4.0
     django42: Django>=4.1

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py38,py39,py310}-django{3.2,4.0,4.1,4.2},py310-django42
+envlist = {py38,py39,py310}-django{32,40,41,42}
 
 [gh-actions]
 python =
@@ -11,7 +11,7 @@ python =
 deps =
     factory_boy==3.2.1
     django32: Django>=3.2,<4.0
-    django40: Django>=4.0
-    django42: Django>=4.1
-    django42: Django>=4.2
+    django40: Django>=4.0,<4.1
+    django41: Django>=4.1,<4.2
+    django42: Django>=4.2,<5.0
 commands = python -Wmodule runtests.py


### PR DESCRIPTION
### Summary

This PR
- Adds support for Django 4.x
- Removes support for Python 3.7
- Updates pre-commit hooks
- Upgrade `factory-boy` and factories


**Tests snapshot**
```
  py38-django3.2: OK (15.51=setup[0.95]+cmd[14.55] seconds)
  py38-django4.0: OK (15.12=setup[0.59]+cmd[14.53] seconds)
  py38-django4.1: OK (15.29=setup[0.62]+cmd[14.67] seconds)
  py38-django4.2: OK (15.29=setup[0.58]+cmd[14.70] seconds)
  py39-django3.2: OK (43.71=setup[0.95]+cmd[42.75] seconds)
  py39-django4.0: OK (42.74=setup[0.99]+cmd[41.75] seconds)
  py39-django4.1: OK (43.42=setup[0.88]+cmd[42.54] seconds)
  py39-django4.2: OK (42.13=setup[0.88]+cmd[41.25] seconds)
  py310-django3.2: OK (15.22=setup[0.64]+cmd[14.58] seconds)
  py310-django4.0: OK (15.16=setup[0.54]+cmd[14.62] seconds)
  py310-django4.1: OK (15.38=setup[0.54]+cmd[14.84] seconds)
  py310-django4.2: OK (15.46=setup[0.62]+cmd[14.84] seconds)
  py310-django42: OK (15.21=setup[0.64]+cmd[14.57] seconds)
  congratulations :) (309.67 seconds)
```