### PR TITLE
Pass request object to filterset class

### DIFF
--- a/bread/bread.py
+++ b/bread/bread.py
@@ -299,7 +299,7 @@ class BrowseView(BreadViewMixin, ListView):
 
         # Now filter
         if self.filterset is not None:
-            self.filter = self.filterset(query_parms, queryset=qset)
+            self.filter = self.filterset(query_parms, queryset=qset, request=self.request)
             qset = self.filter.qs
 
         return qset


### PR DESCRIPTION
What's changed:
- Updated `BrowseView.get_queryset` to pass the request object to the filterset class

Tests snapshot:
![Screenshot 2024-01-02 at 3 51 07 PM](https://github.com/caktus/django_bread/assets/26633909/bdd8b94a-82e3-41a5-a130-651c0d003b34)
